### PR TITLE
CO-1226: Add health check to Textbooks API

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/textbooksapi/TextbooksApplication.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/textbooksapi/TextbooksApplication.groovy
@@ -1,9 +1,11 @@
 package edu.oregonstate.mist.textbooksapi
 
 import edu.oregonstate.mist.api.Application
+import edu.oregonstate.mist.textbooksapi.health.TextbooksHealthCheck
 import edu.oregonstate.mist.textbooksapi.resources.TextbooksResource
 import io.dropwizard.client.HttpClientBuilder
 import io.dropwizard.setup.Environment
+import org.apache.http.client.HttpClient
 
 /**
  * Main application class.
@@ -27,10 +29,15 @@ class TextbooksApplication extends Application<TextbooksConfiguration> {
         if(configuration.httpClient != null) {
             httpClientBuilder.using(configuration.httpClient)
         }
+        HttpClient httpClient = httpClientBuilder.build()
 
         TextbooksCollector textbooksCollector = new TextbooksCollector(
-                httpClientBuilder.build(), configuration.textbooksApi.verbaCompareUri
+                httpClient, configuration.textbooksApi.verbaCompareUri
         )
+        TextbooksHealthCheck textbooksHealthCheck = new TextbooksHealthCheck(
+                httpClient, configuration.textbooksApi.verbaCompareUri
+        )
+        environment.healthChecks().register("TextbooksHealthCheck", textbooksHealthCheck)
 
         environment.jersey().register(new TextbooksResource(textbooksCollector))
     }

--- a/src/main/groovy/edu/oregonstate/mist/textbooksapi/health/TextbooksHealthCheck.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/textbooksapi/health/TextbooksHealthCheck.groovy
@@ -1,0 +1,33 @@
+package edu.oregonstate.mist.textbooksapi.health
+
+import com.codahale.metrics.health.HealthCheck
+import com.codahale.metrics.health.HealthCheck.Result
+import org.apache.http.HttpResponse
+import org.apache.http.HttpStatus
+import org.apache.http.client.HttpClient
+import org.apache.http.client.methods.HttpGet
+
+import javax.ws.rs.core.UriBuilder
+
+class TextbooksHealthCheck extends HealthCheck {
+    private HttpClient httpClient
+    private URI coursesURI
+
+    TextbooksHealthCheck(HttpClient httpClient, String verbaCompareURI) {
+        this.httpClient = httpClient
+        this.coursesURI = UriBuilder.fromPath(verbaCompareURI).path("compare/courses").build()
+    }
+
+    @Override
+    protected Result check() throws Exception {
+        HttpGet req = new HttpGet(coursesURI)
+        HttpResponse res = httpClient.execute(req)
+        int status = res.getStatusLine().getStatusCode()
+
+        if (status == HttpStatus.SC_OK) {
+            Result.healthy()
+        } else {
+            Result.unhealthy("Verba compare URI: ${coursesURI} returned status code: ${status}")
+        }
+    }
+}


### PR DESCRIPTION
The healthcheck queries [verbacompareURI]/compare/courses, passes if the response status is 200, and fails otherwise.