### PR TITLE
quietly consume entity if it's not used

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/textbooksapi/TextbooksCollector.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/textbooksapi/TextbooksCollector.groovy
@@ -131,6 +131,7 @@ class TextbooksCollector {
      */
     HttpResponse getResponse(URI uri) {
         HttpGet req = new HttpGet(uri)
+        logger.info("Sending a request to $uri")
         HttpResponse res = httpClient.execute(req)
         int status = res.getStatusLine().getStatusCode()
 
@@ -141,6 +142,7 @@ class TextbooksCollector {
             Requested URI: ${uri}.
             HTTP response code: ${status}\
             """.stripIndent())
+            EntityUtils.consumeQuietly(res.entity)
             throw new Exception("Something went wrong with Verba compare request")
         }
         res

--- a/src/main/groovy/edu/oregonstate/mist/textbooksapi/health/TextbooksHealthCheck.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/textbooksapi/health/TextbooksHealthCheck.groovy
@@ -6,6 +6,7 @@ import org.apache.http.HttpResponse
 import org.apache.http.HttpStatus
 import org.apache.http.client.HttpClient
 import org.apache.http.client.methods.HttpGet
+import org.apache.http.util.EntityUtils
 
 import javax.ws.rs.core.UriBuilder
 
@@ -22,6 +23,7 @@ class TextbooksHealthCheck extends HealthCheck {
     protected Result check() throws Exception {
         HttpGet req = new HttpGet(coursesURI)
         HttpResponse res = httpClient.execute(req)
+        EntityUtils.consumeQuietly(res.entity)
         int status = res.getStatusLine().getStatusCode()
 
         if (status == HttpStatus.SC_OK) {


### PR DESCRIPTION
jersey will keep the http connection open if the entity wasn't consumed in some way. When all the http connections are used, dropwizard will respond with an exception because there aren't any open http connections